### PR TITLE
fix: update gitlint config

### DIFF
--- a/pre_commit_hooks/oaf_tech_pre_commit_hook.py
+++ b/pre_commit_hooks/oaf_tech_pre_commit_hook.py
@@ -288,7 +288,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "%s .gitlint is not found at gitlint_path %s %s"
                     % (TERMINAL_COLOR_ERROR, gitlint_path, TERMINAL_COLOR_NORMAL)
                 )
-                gitlint_url = "https://raw.githubusercontent.com/one-acre-fund/oaf-pre-commit-hooks/main/.gitignore"
+                gitlint_url = "https://raw.githubusercontent.com/one-acre-fund/oaf-pre-commit-hooks/main/.gitlint"
                 ssl._create_default_https_context = ssl._create_unverified_context
                 with urlopen(gitlint_url) as gitlint_file:
                     gitlint_config = str(gitlint_file.read(), "UTF-8")

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,6 @@
 # Release Notes
+## Release v1.2.1
+. Release for other hooks and gitlint
 
 ## Release v1.1.0
 . Release with pre-commit for commit-msg


### PR DESCRIPTION
The link was wrongfully set to `https://raw.githubusercontent.com/one-acre-fund/oaf-pre-commit-hooks/main/.gitlint` while testing the  method